### PR TITLE
Add Semigroup instance for Vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ cabal.sandbox.config
 *.eventlog
 .stack-work/
 cabal.project.local
+cabal.project.local~
+.ghc.environment.*
 .HTF/
 /haskell-src-exts-util.cabal
 /TAGS

--- a/package.yaml
+++ b/package.yaml
@@ -20,5 +20,6 @@ library:
     - containers
     - data-default
     - haskell-src-exts
+    - semigroups
     - transformers
     - uniplate

--- a/src/Language/Haskell/Exts/FreeVars.hs
+++ b/src/Language/Haskell/Exts/FreeVars.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -16,6 +17,7 @@ module Language.Haskell.Exts.FreeVars
 import           Data.Data
 import           Data.Generics.Uniplate.Data
 import           Data.Monoid (Monoid(..))
+import           Data.Semigroup (Semigroup(..))
 import           Data.Set                      (Set)
 import qualified Data.Set                      as Set
 import           Language.Haskell.Exts
@@ -28,9 +30,14 @@ import           Prelude
 
 data Vars = Vars {bound :: Set (Name ()), free :: Set (Name ())}
 
+instance Semigroup Vars where
+    Vars x1 x2 <> Vars y1 y2 = Vars (x1 ^+ y1) (x2 ^+ y2)
+
 instance Monoid Vars where
     mempty = Vars Set.empty Set.empty
-    mappend (Vars x1 x2) (Vars y1 y2) = Vars (x1 ^+ y1) (x2 ^+ y2)
+#if !(MIN_VERSION_base(4,11,0))
+    mappend = (<>)
+#endif
     mconcat fvs = Vars (Set.unions $ map bound fvs) (Set.unions $ map free fvs)
 
 class AllVars a where


### PR DESCRIPTION
Currently, `haskell-src-exts-util-0.2.1.2` fails to build on GHC 8.4.1 since `Semigroup` has become a superclass of `Monoid`, and `Vars` lacks a `Semigroup` instance. This fixes the issue.

I opted to avoid some CPP by depending on the `semigroups` package to provide the `Semigroup` class on GHC 7.10 and earlier (before `Semigroup` was added to `base`). If you'd prefer to avoid incurring an extra dependency, I could alternatively remove the `semigroups` dependency and only define the `Semigroup` instances on `base-4.9` or later (at the cost of some CPP).
  