### PR TITLE
Resolve Ambiguous module name error.

### DIFF
--- a/src/Language/Haskell/Exts/FreeVars.hs
+++ b/src/Language/Haskell/Exts/FreeVars.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE PackageImports      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
@@ -18,7 +19,7 @@ import           Control.Monad
 import           Data.Data
 import           Data.Generics.Uniplate.Data
 import           Data.Monoid (Monoid(..))
-import           Data.Semigroup (Semigroup(..))
+import           "semigroups" Data.Semigroup (Semigroup(..))
 import           Data.Set                      (Set)
 import qualified Data.Set                      as Set
 import           Language.Haskell.Exts


### PR DESCRIPTION
Resolves a compilation error regarding a confusion between using "base" or "semigroups" to import Data.Semigroup from:

src/Language/Haskell/Exts/FreeVars.hs:21:1: error:
    Ambiguous module name `Data.Semigroup':
      it was found in multiple packages: base-4.10.1.0 semigroups-0.9.2
   |
21 | import           Data.Semigroup (Semigroup(..))
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^