### PR TITLE
Things inside a TupleSection do not need brackets

### DIFF
--- a/src/Language/Haskell/Exts/Bracket.hs
+++ b/src/Language/Haskell/Exts/Bracket.hs
@@ -93,6 +93,7 @@ instance (Data l, Default l) => Brackets (Exp l) where
         | ListComp{} <- parent = False
         | List{} <- parent = False
         | Tuple{} <- parent = False
+        | TupleSection{} <- parent = False
         | If{} <- parent, isAnyApp child = False
         | App{} <- parent, i == 0, App{} <- child = False
         | ExpTypeSig{} <- parent, i == 0, isApp child = False


### PR DESCRIPTION
Something I spotted while adding TupleSection suggestions to hlint in https://github.com/ndmitchell/hlint/issues/470