### PR TITLE
Fix spotting brackets inside in a Lambda

### DIFF
--- a/src/Language/Haskell/Exts/Bracket.hs
+++ b/src/Language/Haskell/Exts/Bracket.hs
@@ -101,7 +101,7 @@ instance (Data l, Default l) => Brackets (Exp l) where
         | RecConstr{} <- parent = False
         | RecUpdate{} <- parent, i /= 0 = False
         | Case{} <- parent, i /= 0 || isAnyApp child = False
-        | Lambda{} <- parent, i == length (universeBi parent :: [Pat l]) - 1 = False -- watch out for PViewPat
+        | Lambda{} <- parent = False -- might be either the RHS of a PViewPat, or the lambda body (neither needs brackets)
         | Do{} <- parent = False
         | otherwise = True
 


### PR DESCRIPTION
The previous code tried to account for `\(a -> b) -> c` - noting that `b` was not the body of a lambda, so shouldn't be marked as not requiring brackets. However, it was the body of a view pattern, so didn't need brackets, so the whole dance was pointless. Furthermore, the whole dance was wrong twice over, and the original code, with the original flawed logic, should have read:

    | Lambda{} <- parent, i == length (children parent) - 1 = False