### PR TITLE
Make freeVars on Foo{a} include 'a'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+ - Make freeVars on Foo{a} include 'a'
 # 0.2.4
  - Neil fixed the spotting of brackets inside a lambda.
 # 0.2.3

--- a/src/Language/Haskell/Exts/FreeVars.hs
+++ b/src/Language/Haskell/Exts/FreeVars.hs
@@ -95,10 +95,17 @@ instance (Data s, Ord s) => FreeVars (Exp s) where -- never has any bound variab
     freeVars (Case _ x alts) = freeVars x `mappend` freeVars alts
     freeVars (Do _ xs) = free $ allVars xs
     freeVars (MDo l xs) = freeVars $ Do l xs
+    freeVars (RecConstr _ _ a) = Set.unions $ map freeVars a
+    freeVars (RecUpdate _ a b) = Set.unions $ freeVars a : map freeVars b
     freeVars (ParComp _ x xs) = free xfv ^+ (freeVars x ^- bound xfv)
         where xfv = mconcat $ map allVars xs
     freeVars (ListComp l x xs) = freeVars $ ParComp l x [xs]
     freeVars x = freeVars $ children x
+
+instance (Data s, Ord s) => FreeVars (FieldUpdate s) where
+    freeVars (FieldUpdate _ _ x) = freeVars x
+    freeVars (FieldPun _ x) = Set.fromList $ unqualNames x
+    freeVars (FieldWildcard _) = Set.empty -- have no idea what's in here
 
 instance (Data s, Ord s) => FreeVars [Exp s] where
     freeVars = Set.unions . map freeVars


### PR DESCRIPTION
Previously `Foo{a}` didn't mark `a` as a free variable, leading to https://github.com/ndmitchell/hlint/issues/536