### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,8 @@ library:
     - containers
     - data-default
     - haskell-src-exts >= 1.20.0
-    - semigroups
     - transformers
     - uniplate
+  when:
+    - condition: impl(ghc < 8.0)
+      dependencies: semigroups


### PR DESCRIPTION
They are not needed on newer GHC.